### PR TITLE
feat: add Go fuzz tests for OpenSSF Scorecard fuzzing check

### DIFF
--- a/pkg/infrastructure/report/fuzz_test.go
+++ b/pkg/infrastructure/report/fuzz_test.go
@@ -1,0 +1,32 @@
+package report
+
+import "testing"
+
+func FuzzHumanSize(f *testing.F) {
+	f.Add(int64(0))
+	f.Add(int64(1024))
+	f.Add(int64(1048576))
+	f.Add(int64(1073741824))
+	f.Add(int64(-1))
+	f.Add(int64(9999999999999))
+
+	f.Fuzz(func(t *testing.T, numBytes int64) {
+		result := HumanSize(numBytes)
+		if result == "" {
+			t.Error("HumanSize returned empty string")
+		}
+	})
+}
+
+func FuzzFormatDigest(f *testing.F) {
+	f.Add("sha256:abcdef1234567890abcdef1234567890")
+	f.Add("")
+	f.Add("sha256:short")
+	f.Add("not-a-digest")
+	f.Add("sha256:")
+
+	f.Fuzz(func(t *testing.T, digest string) {
+		// FormatDigest must not panic on any input
+		_ = FormatDigest(digest)
+	})
+}

--- a/pkg/infrastructure/scanner/fuzz_test.go
+++ b/pkg/infrastructure/scanner/fuzz_test.go
@@ -1,0 +1,89 @@
+package scanner
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzFilterTags(f *testing.F) {
+	// Seed corpus
+	f.Add("latest")
+	f.Add("3.12")
+	f.Add("20.14-nonroot")
+	f.Add("3.0.20240824")
+	f.Add("arm64-debug")
+	f.Add("v1.0.0-beta.1")
+	f.Add("")
+	f.Add("!@#$%^&*()")
+
+	cfg := DefaultTagFilter()
+
+	f.Fuzz(func(t *testing.T, tag string) {
+		// FilterTags must not panic on any input
+		result := FilterTags([]string{tag}, cfg)
+		if len(result) > 1 {
+			t.Errorf("FilterTags returned more tags than input: got %d", len(result))
+		}
+	})
+}
+
+func FuzzParseImagePatterns(f *testing.F) {
+	f.Add("azurelinux/base/python")
+	f.Add("docker.io/library/python:3-slim")
+	f.Add("mcr.microsoft.com/dotnet/aspnet:8.0")
+	f.Add("")
+	f.Add("repo:with:multiple:colons")
+	f.Add("a/b/c/d/e/f")
+
+	f.Fuzz(func(t *testing.T, pattern string) {
+		// ParseImagePatterns must not panic on any input
+		repos, singles := ParseImagePatterns([]string{pattern})
+		total := len(repos) + len(singles)
+		if pattern != "" && total == 0 {
+			t.Errorf("non-empty pattern %q produced no output", pattern)
+		}
+	})
+}
+
+func FuzzBuildFullImageName(f *testing.F) {
+	f.Add("mcr.microsoft.com", "azurelinux/base/python", "3.12")
+	f.Add("", "docker.io/library/node", "20-slim")
+	f.Add("registry.example.com", "repo", "latest")
+
+	f.Fuzz(func(t *testing.T, registry, repo, tag string) {
+		// BuildFullImageName must not panic on any input
+		result := BuildFullImageName(registry, repo, tag)
+		if result == "" {
+			t.Error("BuildFullImageName returned empty string")
+		}
+	})
+}
+
+func FuzzCleanVersion(f *testing.F) {
+	f.Add("3.12.9")
+	f.Add("3.12.9-1.azl3")
+	f.Add("21.0.10+7-LTS")
+	f.Add("")
+	f.Add("not-a-version")
+
+	f.Fuzz(func(t *testing.T, version string) {
+		// cleanVersion must not panic on any input
+		_ = cleanVersion(version)
+	})
+}
+
+func FuzzParseSyftResult(f *testing.F) {
+	f.Add(`{"artifacts":[]}`)
+	f.Add(`{"artifacts":[{"name":"python","version":"3.12","type":"binary","metadata":{}}]}`)
+	f.Add(`{}`)
+	f.Add(``)
+	f.Add(`{"artifacts": null}`)
+
+	f.Fuzz(func(t *testing.T, jsonData string) {
+		// parseSyftResult must not panic on any JSON input
+		var output syftOutput
+		if err := json.Unmarshal([]byte(jsonData), &output); err == nil {
+			_ = parseSyftResult(&output)
+		}
+	})
+}


### PR DESCRIPTION
Adds Go fuzz tests for key parsing and formatting functions to improve the OpenSSF Scorecard Fuzzing check score.

## Fuzz tests added

| Test | Function | Purpose |
|------|----------|---------|
| FuzzFilterTags | FilterTags() | Tag filtering robustness |
| FuzzParseImagePatterns | ParseImagePatterns() | Image pattern parsing |
| FuzzBuildFullImageName | BuildFullImageName() | Image name construction |
| FuzzCleanVersion | cleanVersion() | Version string cleaning |
| FuzzParseSyftResult | parseSyftResult() | Syft JSON parsing |
| FuzzHumanSize | HumanSize() | Byte size formatting |
| FuzzFormatDigest | FormatDigest() | Digest string formatting |

All fuzz tests verified locally (5s each, no failures).