### PR TITLE
config: expand nightly scan images with .NET 9/10, OpenJDK 25/17/11, and comparison images

### DIFF
--- a/config/repositories.json
+++ b/config/repositories.json
@@ -13,6 +13,7 @@
     {
       "description": "Azure Linux base images",
       "images": [
+        "azurelinux/base/core",
         "azurelinux/base/python",
         "azurelinux/base/nodejs"
       ]
@@ -21,16 +22,18 @@
       "description": "Azure Linux distroless images",
       "images": [
         "azurelinux/distroless/base",
+        "azurelinux/distroless/minimal",
         "azurelinux/distroless/python",
         "azurelinux/distroless/nodejs"
       ]
     },
     {
-      "description": "Docker Hub single images",
+      "description": "Docker Hub images (for comparison)",
       "images": [
         "docker.io/library/python:3-slim",
         "docker.io/library/python:3.12-slim",
-        "docker.io/library/node:20.0-slim"
+        "docker.io/library/node:20.0-slim",
+        "docker.io/library/node:22-bookworm-slim"
       ]
     },
     {
@@ -38,15 +41,26 @@
       "images": [
         "mcr.microsoft.com/dotnet/aspnet:8.0",
         "mcr.microsoft.com/dotnet/runtime:8.0",
-        "mcr.microsoft.com/dotnet/sdk:8.0"
+        "mcr.microsoft.com/dotnet/sdk:8.0",
+        "mcr.microsoft.com/dotnet/aspnet:10.0-azurelinux3.0-distroless",
+        "mcr.microsoft.com/dotnet/aspnet:9.0-azurelinux3.0-distroless",
+        "mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless",
+        "mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0-distroless",
+        "mcr.microsoft.com/dotnet/runtime:9.0-azurelinux3.0-distroless",
+        "mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0",
+        "mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0"
       ]
     },
     {
       "description": "OpenJDK images",
       "images": [
+        "mcr.microsoft.com/openjdk/jdk:25-azurelinux",
+        "mcr.microsoft.com/openjdk/jdk:25-distroless",
         "mcr.microsoft.com/openjdk/jdk:21-azurelinux",
         "mcr.microsoft.com/openjdk/jdk:21-distroless",
-        "mcr.microsoft.com/openjdk/jdk:21-ubuntu"
+        "mcr.microsoft.com/openjdk/jdk:21-ubuntu",
+        "mcr.microsoft.com/openjdk/jdk:17-distroless",
+        "mcr.microsoft.com/openjdk/jdk:11-distroless"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Expand the nightly scan configuration to cover more MCR Azure Linux images.

### Changes

**New images added:**
- **Azure Linux base**: `azurelinux/base/core`
- **Azure Linux distroless**: `azurelinux/distroless/minimal`
- **.NET Azure Linux distroless**: aspnet, runtime, sdk for 10.0, 9.0, 8.0
- **OpenJDK**: 25-azurelinux, 25-distroless, 17-distroless, 11-distroless
- **Docker Hub comparison**: `node:22-bookworm-slim`

**Preserved (all existing images from daily_recommendations.md):**
- All Azure Linux base/distroless Python and Node.js images
- Docker Hub python:3-slim, python:3.12-slim, node:20.0-slim
- .NET aspnet:8.0, runtime:8.0, sdk:8.0 (generic tags)
- OpenJDK 21-azurelinux, 21-distroless, 21-ubuntu