### PR TITLE
Fix Go config: use pinned images instead of tag discovery

### DIFF
--- a/config/repositories.json
+++ b/config/repositories.json
@@ -54,7 +54,8 @@
     {
       "description": "Go images",
       "images": [
-        "oss/go/microsoft/golang"
+        "mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0",
+        "mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0"
       ]
     },
     {


### PR DESCRIPTION
The Go repository (`oss/go/microsoft/golang`) has **6,790 tags** spanning Windows, Debian, bullseye, nanoserver, etc. With `maxTags: 0` (unlimited), tag discovery would attempt to scan thousands of irrelevant images.

Switch to pinned Azure Linux tags:
- `mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0`
- `mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0`

This matches the pattern used for .NET and OpenJDK pinned images.