### PR TITLE
ci: add OpenSSF Scorecard workflow (weekly schedule)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: 🛡️ OpenSSF Scorecard
+
+on:
+  # For Branch-Protection check. Only the default branch is supported.
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # Weekly schedule to keep the Maintained check updated.
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "30 3 * * 1"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Deny all permissions by default; grant only what's needed at job level.
+permissions: {}
+
+jobs:
+  scorecard:
+    name: 🛡️ Scorecard Analysis
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read # Checkout repository
+      security-events: write # Upload SARIF to code-scanning dashboard
+      id-token: write # Publish results and obtain badge
+
+    steps:
+      - name: ⤵️ Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🛡️ Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: 📤 Upload SARIF artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: 📤 Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds an OpenSSF Scorecard GitHub Actions workflow for continuous security health assessment.

Closes #26

## What's included

- **Weekly schedule** — runs every Monday at 03:30 UTC
- **Additional triggers** — `push` to `main`, `branch_protection_rule`, and `workflow_dispatch`
- **SARIF upload** — results appear in the GitHub code-scanning dashboard
- **Artifact upload** — SARIF file retained for 5 days
- **OpenSSF publishing** — enables the Scorecard badge

## Security hardening

- All 4 actions pinned to full commit SHAs (no mutable tags)
- Top-level `permissions: {}` with minimal job-level grants (`security-events: write`, `id-token: write`)
- Pinned runner `ubuntu-24.04` (not `ubuntu-latest`)
- `persist-credentials: false` on checkout
- `timeout-minutes: 10`

## Testing

The `workflow_dispatch` trigger allows testing from this branch before merging:

```bash
gh workflow run scorecard.yml --ref feature/openssf-scorecard
```

Once validated, `workflow_dispatch` remains useful for on-demand runs post-merge.