### PR TITLE
docs: remove Background section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,6 @@ config/                        # Image sources and tag filter config
 docs/                          # Generated daily reports
 ```
 
-## Background
-
-This project replicates and extends the nightly recommendations pipeline from [secure-container-base-image-recommender](https://github.com/maniSbindra/secure-container-base-image-recommender) (Python) in Go.
-
 ## License
 
 MIT


### PR DESCRIPTION
Removes the Background section that referenced the Python predecessor project ([secure-container-base-image-recommender](https://github.com/maniSbindra/secure-container-base-image-recommender)). That repository has been archived and its description now redirects to this project, so the reference is no longer needed.