### PR TITLE
fix: centralize installer SHAs as named variables in install-tools.sh

### DIFF
--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Installer SHAs — update these when bumping tool versions
+SYFT_VERSION="v1.42.3"
+SYFT_INSTALLER_SHA="860126c650c2d05b63b83a3895e41268162315a3" # v1.42.3 anchore/syft install.sh
+
+TRIVY_VERSION="v0.69.3"
+TRIVY_INSTALLER_SHA="6fb20c8edd70745d6b34bff0387b53b03c8a760a" # v0.69.3 aquasecurity/trivy contrib/install.sh
+
+GOLANGCI_LINT_VERSION="v2.11.4"
+GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7ed018e57905fbd873c697e0b1ede605a5" # v2.11.4 golangci/golangci-lint install.sh
+
 echo "=== Installing scanning tools ==="
 
 # Syft (SBOM generator)
 echo "Installing Syft..."
-curl -sSfL https://raw.githubusercontent.com/anchore/syft/860126c650c2d05b63b83a3895e41268162315a3/install.sh | sudo sh -s -- -b /usr/local/bin v1.42.3
+curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_INSTALLER_SHA}/install.sh" | sudo sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
 
 # Trivy (vulnerability scanner)
 echo "Installing Trivy..."
-curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/6fb20c8edd70745d6b34bff0387b53b03c8a760a/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_INSTALLER_SHA}/contrib/install.sh" | sudo sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
 # golangci-lint
 echo "Installing golangci-lint..."
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/8f3b0c7ed018e57905fbd873c697e0b1ede605a5/install.sh | sudo sh -s -- -b /usr/local/bin v2.11.4
+curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_INSTALLER_SHA}/install.sh" | sudo sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
 
 echo "=== Tools installed ==="
 syft version


### PR DESCRIPTION
## Summary

Moves SHA and version strings for Syft, Trivy, and golangci-lint from inline `curl` commands to named variables at the top of `.devcontainer/install-tools.sh`, following the same pattern applied in [Azure/mpf#246](https://github.com/Azure/mpf/pull/246).

## Changes

```diff
+# Installer SHAs — update these when bumping tool versions
+SYFT_VERSION="v1.42.3"
+SYFT_INSTALLER_SHA="860126c..." # v1.42.3 anchore/syft install.sh
+
+TRIVY_VERSION="v0.69.3"
+TRIVY_INSTALLER_SHA="6fb20c8..." # v0.69.3 aquasecurity/trivy contrib/install.sh
+
+GOLANGCI_LINT_VERSION="v2.11.4"
+GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7..." # v2.11.4 golangci/golangci-lint install.sh
```

The `curl` commands now reference these variables instead of embedding values inline.

## Benefits

- Version/SHA updates are a single-line change at the top of the file
- Easier to review and audit pinned dependencies at a glance

Closes #42