### PR TITLE
fix: centralize tool version SHAs into .github/tool-versions.sh

### DIFF
--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Installer SHAs — update these when bumping tool versions
-SYFT_VERSION="v1.42.3"
-SYFT_INSTALLER_SHA="860126c650c2d05b63b83a3895e41268162315a3" # v1.42.3 anchore/syft install.sh
-
-TRIVY_VERSION="v0.69.3"
-TRIVY_INSTALLER_SHA="6fb20c8edd70745d6b34bff0387b53b03c8a760a" # v0.69.3 aquasecurity/trivy contrib/install.sh
-
-GOLANGCI_LINT_VERSION="v2.11.4"
-GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7ed018e57905fbd873c697e0b1ede605a5" # v2.11.4 golangci/golangci-lint install.sh
+# Source centralised tool versions (single source of truth)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../.github/tool-versions.sh
+source "${SCRIPT_DIR}/../.github/tool-versions.sh"
 
 echo "=== Installing scanning tools ==="
 

--- a/.github/tool-versions.sh
+++ b/.github/tool-versions.sh
@@ -1,0 +1,11 @@
+# Tool versions and installer SHAs — single source of truth
+# Update versions here; all workflows and install-tools.sh source this file.
+
+SYFT_VERSION="v1.42.3"
+SYFT_INSTALLER_SHA="860126c650c2d05b63b83a3895e41268162315a3" # anchore/syft install.sh
+
+TRIVY_VERSION="v0.69.3"
+TRIVY_INSTALLER_SHA="6fb20c8edd70745d6b34bff0387b53b03c8a760a" # aquasecurity/trivy contrib/install.sh
+
+GOLANGCI_LINT_VERSION="v2.11.4"
+GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7ed018e57905fbd873c697e0b1ede605a5" # golangci/golangci-lint install.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,9 +57,15 @@ jobs:
       - name: 🚧 Setup Task
         uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
 
+      - name: 📌 Load tool versions
+        if: matrix.task == 'go'
+        run: |
+          source .github/tool-versions.sh
+          echo "GOLANGCI_LINT_VERSION=$GOLANGCI_LINT_VERSION" >> "$GITHUB_ENV"
+
       - name: 🔨 Install golangci-lint
         if: matrix.task == 'go'
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
       - name: ✔️ Run lint (${{ matrix.task }})
         run: task lint:${{ matrix.task }}

--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -50,13 +50,21 @@ jobs:
       - name: 🏗️ Build
         run: task build
 
+      - name: 📌 Load tool versions
+        run: |
+          source .github/tool-versions.sh
+          echo "SYFT_VERSION=$SYFT_VERSION" >> "$GITHUB_ENV"
+          echo "SYFT_INSTALLER_SHA=$SYFT_INSTALLER_SHA" >> "$GITHUB_ENV"
+          echo "TRIVY_VERSION=$TRIVY_VERSION" >> "$GITHUB_ENV"
+          echo "TRIVY_INSTALLER_SHA=$TRIVY_INSTALLER_SHA" >> "$GITHUB_ENV"
+
       - name: 🔧 Install Syft
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/860126c650c2d05b63b83a3895e41268162315a3/install.sh | sh -s -- -b /usr/local/bin v1.42.3
+          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_INSTALLER_SHA}/install.sh" | sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
 
       - name: 🔧 Install Trivy
         run: |
-          curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/6fb20c8edd70745d6b34bff0387b53b03c8a760a/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
+          curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_INSTALLER_SHA}/contrib/install.sh" | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
       - name: 🐳 Docker info
         run: docker info

--- a/.github/workflows/scan-smoke-test.yml
+++ b/.github/workflows/scan-smoke-test.yml
@@ -47,13 +47,21 @@ jobs:
       - name: 🏗️ Build
         run: task build
 
+      - name: 📌 Load tool versions
+        run: |
+          source .github/tool-versions.sh
+          echo "SYFT_VERSION=$SYFT_VERSION" >> "$GITHUB_ENV"
+          echo "SYFT_INSTALLER_SHA=$SYFT_INSTALLER_SHA" >> "$GITHUB_ENV"
+          echo "TRIVY_VERSION=$TRIVY_VERSION" >> "$GITHUB_ENV"
+          echo "TRIVY_INSTALLER_SHA=$TRIVY_INSTALLER_SHA" >> "$GITHUB_ENV"
+
       - name: 🔧 Install Syft
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/860126c650c2d05b63b83a3895e41268162315a3/install.sh | sh -s -- -b /usr/local/bin v1.42.3
+          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_INSTALLER_SHA}/install.sh" | sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
 
       - name: 🔧 Install Trivy
         run: |
-          curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/6fb20c8edd70745d6b34bff0387b53b03c8a760a/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
+          curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_INSTALLER_SHA}/contrib/install.sh" | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
       - name: 🔍 Run smoke test scan
         run: |


### PR DESCRIPTION
## Summary

Moves all remaining inline tool version strings and installer SHAs from workflow files into a single shared `.github/tool-versions.sh`, extending the work from #43.

Closes #45

## Changes

**New file:** `.github/tool-versions.sh`
```sh
SYFT_VERSION="v1.42.3"
SYFT_INSTALLER_SHA="860126c..."
TRIVY_VERSION="v0.69.3"
TRIVY_INSTALLER_SHA="6fb20c8..."
GOLANGCI_LINT_VERSION="v2.11.4"
GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7..."
```

**Updated files (now source the shared file):**
- `.devcontainer/install-tools.sh` — removed inline variables, sources shared file
- `.github/workflows/nightly-scan.yml` — loads versions into \$GITHUB_ENV
- `.github/workflows/scan-smoke-test.yml` — same pattern
- `.github/workflows/lint.yml` — loads golangci-lint version

## Benefits

- Version/SHA bumps are a **single-line change** in one file
- No more drift between devcontainer and CI tool versions
- Easier to audit pinned dependencies at a glance